### PR TITLE
Add SWITCH_GAME_SUGGESTION to SERVER_CUSTOM_TYPES

### DIFF
--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -122,8 +122,19 @@ export enum PLAYER_UPGRADE_TYPES {
  * SERVER_PACKETS.SERVER_CUSTOM types.
  */
 export enum SERVER_CUSTOM_TYPES {
+  /**
+   * For the conclusion of BTR and CTF game types.
+   *
+   * Note: these are the only two types that are compatible with Q-bots;
+   *       other SERVER_CUSTOM types must not be sent to these clients. 
+   */
   BTR = 1,
   CTF = 2,
+
+  /**
+   * For suggesting to the player a different game server to switch to.
+   */
+  SWITCH_GAME_SUGGESTION = 100,
 }
 
 /**


### PR DESCRIPTION
This `SERVER_CUSTOM` type is for displaying messages like this in the frontend:

![switch-game-suggestion-frontend-screenshot](https://user-images.githubusercontent.com/45519482/115127116-dffcdb80-9fcb-11eb-9c57-e4237e383ddd.png)

Related commit: https://github.com/airmash-refugees/airmash-frontend/commit/70eeafb55716be04383144ef96c21af82980adfc

I added this to `SERVER_CUSTOM` rather than using `SERVER_MESSAGE` because it requires custom HTML for the button, and since commit https://github.com/airmash-refugees/airmash-frontend/commit/4ecd597ba3cba231b177a0656b7aa9ac9242e48a the frontend restricts the `SERVER_MESSAGE` HTML only to that used in CTF flag messages, to avoid XSS vectors.